### PR TITLE
Fixed: Columns of 'hour' and 'duration'

### DIFF
--- a/web/page/rules.js
+++ b/web/page/rules.js
@@ -82,12 +82,12 @@
 				{
 					key      : 'hour',
 					innerHTML: '時間帯',
-					width    : 60
+					width    : 40
 				},
 				{
 					key      : 'duration',
 					innerHTML: '長さ',
-					width    : 60
+					width    : 70
 				},
 				{
 					key      : 'reserve_titles',
@@ -156,6 +156,20 @@
 						ignore_flags: {
 							innerHTML: !!rule.ignore_flags ? (
 								rule.ignore_flags.join('<br>')
+							) : (
+								'-'
+							)
+						},
+						hour: {
+							innerHTML: !!rule.hour ? (
+								rule.hour.start + " - " + rule.hour.end
+							) : (
+								'-'
+							)
+						},
+						duration: {
+							innerHTML: !!rule.duration ? (
+								rule.duration.min + " - " + rule.duration.max
 							) : (
 								'-'
 							)


### PR DESCRIPTION
些細なことですが、ルールにて表示されていないカラムが気になったので修正しました。
・時間帯と長さの表示を追加
・カラム幅の変更

文字列をダブルクォーテーションで括っているので、気になった場合は修正してください。
