### PR TITLE
rulesオプションの表示結果にrule_idを追加

### DIFF
--- a/app-cli.js
+++ b/app-cli.js
@@ -17,6 +17,7 @@ var fs            = require('fs');
 var util          = require('util');
 var net           = require('net');
 var child_process = require('child_process');
+var crc           = require('crc');
 
 // ディレクトリチェック
 if (!fs.existsSync('./data/') || !fs.existsSync('./log/') || !fs.existsSync('./web/')) {
@@ -366,9 +367,19 @@ function chinachuRuleList() {
 		
 		t.cell('#', i);
 		
+		// for rule_id
+		var allStr = '';
+		t.cell('rule_id', '');
+
 		keys.forEach(function(b) {
 			switch (typeof a[b]) {
 				case 'object':
+					var val = [];
+					Object.keys(a[b]).forEach(function(c, j) {
+						val[j] = a[b][c];
+					});
+					allStr += val;
+ 
 					if (
 						!opts.get('detail') && (
 							(b.indexOf('titles') !== -1) ||
@@ -377,24 +388,25 @@ function chinachuRuleList() {
 					) {
 						t.cell(b, '[' + Object.keys(a[b]).length + ']');
 					} else {
-						var val = [];
-						Object.keys(a[b]).forEach(function(c, j) {
-							val[j] = a[b][c];
-						});
 						t.cell(b, val.join(', '));
 					}
 					break;
 				
 				case 'string':
+					allStr += a[b];
 					t.cell(b, a[b]);
 					break;
 				
 				case 'undefined':
+					allStr += '-';
 					t.cell(b, '-');
 					break;
 			}
 		});
-		
+
+		var hash = Math.abs(crc.crc32(allStr)).toString(16);
+		t.cell('rule_id', ('0000000' + hash).slice(-8));
+
 		t.newRow();
 	});
 	

--- a/chinachu
+++ b/chinachu
@@ -132,6 +132,7 @@ chinachu_installer_node_modules () {
   chinachu_installer_node_modules_install opts
   chinachu_installer_node_modules_install socket.io
   chinachu_installer_node_modules_install xml2js
+  chinachu_installer_node_modules_install crc
   
   echo "done."
   


### PR DESCRIPTION
ルールに指定された文字列を元にCRC32にてハッシュ値を算出し、8桁16進のrule_idとして出力しています。
./chinachu unrule &lt;ruleid&gt;での利用を想定して作成しました。
重複ルールの場合などに関する処理はしていないので、その時はrule_idが同一になります。
nodeモジュールのcrcを使用したんですが、ほかにいいものがあれば差し換えてください。
![cap_201212242305](https://f.cloud.github.com/assets/2971112/29841/1178e388-4dd3-11e2-80b1-a6d7423cd638.png)
