### PR TITLE
Fixed:手動予約時のフラグの統一

### DIFF
--- a/app-cli.js
+++ b/app-cli.js
@@ -397,7 +397,7 @@ function chinachuReserve() {
 		process.exit(1);
 	}
 	
-	target.isManualReserve = true;
+	target.isManualReserved = true;
 	
 	reserves.push(target);
 	
@@ -425,7 +425,7 @@ function chinachuUnreserve() {
 		process.exit(1);
 	}
 	
-	if (!target.isManualReserve) {
+	if (!target.isManualReserved) {
 		util.error('自動予約された番組は解除できません。自動予約ルールを編集してください');
 		process.exit(1);
 	}


### PR DESCRIPTION
手動予約のフラグがisManualReserveとisManualReserve<b>d</b>の二つ存在していたので、後者に統一しました。
