### PR TITLE
change handling of wuiHost

### DIFF
--- a/app-wui.js
+++ b/app-wui.js
@@ -179,7 +179,12 @@ var status = {
 //
 if (http)  { var app = http.createServer(httpServer); }
 if (https) { var app = https.createServer(tlsOption, httpServer); }
-app.listen(config.wuiPort, config.wuiHost || '::');
+
+if (config.wuiHost != null) {
+	app.listen(config.wuiPort, config.wuiHost);
+} else {
+	app.listen(config.wuiPort);
+}
 
 function httpServer(req, res) {
 	if (req.method === 'GET') {

--- a/config.sample.json
+++ b/config.sample.json
@@ -7,7 +7,7 @@
   ],
   
   "wuiPort"        : 10772,
-  "wuiHost"        : "::",
+  "wuiHost"        : null,
   "wuiTlsKeyPath"  : null,
   "wuiTlsCertPath" : null,
   "wuiPreviewer"   : true,


### PR DESCRIPTION
wuiHostの初期値がIPv6前提になっているので非対応の環境ではwui起動時に
info: socket.io started
warn: error raised: Error: listen EAFNOSUPPORT
となり起動できない
初期値をnullにしてその場合はhostnameを使用せずにlistenを呼び出して
デフォルト(INADDR_ANY)で待ち受けるようにする
