### PR TITLE
タイトル抽出の修正

### DIFF
--- a/app-scheduler.js
+++ b/app-scheduler.js
@@ -776,7 +776,7 @@ function convertPrograms(p, ch) {
 		var title = c.title[0]._
 			.replace(/【.{1,2}】/g, '')
 			.replace(/\[.\]/g, '')
-			.replace(/[^版]「.+」/g, '')
+			.replace(/([^版])「.+」/g, '$1')
 			.replace(/(#[0-9]+|(＃|♯)[０１２３４５６７８９]+)/g, '')
 			.replace(/第([0-9]+|[０１２３４５６７８９零一壱二弐三参四五伍六七八九十拾]+)話/g, '')
 			.replace(/([0-9]+|[０１２３４５６７８９]+)品目/g, '')


### PR DESCRIPTION
タイトル抽出パターンに `[^版]` が追加されたことにより、話数抽出やタイトル抽出が失敗しています。

例えば:
- フルタイトル: ほげほげ「ふがふが」→ 抽出されたタイトル: ほげほ
- フルタイトル: ほげほげ　第13話「ふがふが」→ 抽出されたタイトル: ほげほげ　第13、話数抽出失敗

その修正です。
