### PR TITLE
Fix scheduling bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ node_modules/mocha
 node_modules/should
 node_modules/sinon
 node_modules/spdy
+*~
+.node-gyp
+.npm

--- a/app-scheduler.js
+++ b/app-scheduler.js
@@ -641,6 +641,11 @@ function scheduler() {
 		if (reserve.isManualReserved) matches.push(reserve);
 	});
 
+	// sort
+	matches.sort(function(a, b) {
+		return a.start - b.start;
+	});
+
 	// duplicates
 	var duplicateCount = 0;
 	for (var i = 0; i < matches.length; i++) {
@@ -705,11 +710,6 @@ function scheduler() {
 			++conflictCount;
 		}
 	}
-
-	// sort
-	matches.sort(function(a, b) {
-		return a.start - b.start;
-	});
 
 	// reserve
 	reserves = [];


### PR DESCRIPTION
@kiyooka さんの #24 に対する修正 https://github.com/kiyooka/Chinachu/commit/39e506f81b25da3c448056ea42ee16d88e4e5f07 から更にバグ修正
## 修正したバグについて

3つの放送局において以下のようなケースの時:

```
 MX|--programA---|
TBS|         |---programB---||---programC---|
NTV|               |---programD---|
```

衝突判定の順番が A, B, C, D だと、B, C が別の `tunerThread` に入ってしまい、D が衝突扱いされてしまう。

番組開始時間順にソートしてから、衝突判定することで解決。
