### PR TITLE
Scheduler: 重複による予約対象外の番組が衝突チェック時にカウントされてしまう問題の修正

### DIFF
--- a/app-scheduler.js
+++ b/app-scheduler.js
@@ -766,6 +766,9 @@ function scheduler() {
 	}
 	for (var i = 0; i < matches.length; i++) {
 		var a = matches[i];
+
+		if (a.isDuplicate) continue;
+
 		a.isConflict = true;
 		
 		for (var k = 0; k < config.tuners.length; k++) {


### PR DESCRIPTION
番組情報が重複しているために予約対象外とされている番組 (323fa51d1f69de7e3e127f1fa841d201eb57d68a) が、衝突チェック時のカウントに含まれてしまう問題への対処です。
重複が発生している番組を予約すると、チューナー数に余裕があるにも関わらず裏番組の予約と衝突しているとして警告が表示される現象が発生していました。
