### PR TITLE
Scheduler: epgdumpから得られたEPG情報が空であった場合にリトライする

### DIFF
--- a/app-scheduler.js
+++ b/app-scheduler.js
@@ -327,6 +327,13 @@ function getEpg() {
 							
 							return;
 						}
+
+						if (result.tv.channel === undefined) {
+							util.log('EPG: データが空 (result.tv.channel is undefined)');
+							process.nextTick(retry);
+
+							return;
+						}
 						
 						if (
 							!result.tv.channel[0]['display-name'] ||


### PR DESCRIPTION
番組表更新時に何らかの問題で epgdump の出力する XML データに番組情報が含まれていない場合であっても正常にリトライが行われるようにする修正です。

epgdump にEPG情報が含まれていない .m2ts ファイルや 0 バイトのファイルを入力すると下記のような XML が出力されます。

``` xml
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE tv SYSTEM "xmltv.dtd">

<tv generator-info-name="tsEPG2xml" generator-info-url="http://localhost/">
</tv>
```

この XML を受け取った app-scheduler.js は `EPG: エラー (TypeError: Cannot read property '0' of undefined)` を出力して番組表の更新に失敗してしまうため、この修正では channel 要素が含まれていない XML を受け取った場合に不正なデータとしてリトライが行われるようにします。
