### PR TITLE
未ハンドルエラーに対する処理を改善

### DIFF
--- a/app-operator.js
+++ b/app-operator.js
@@ -462,19 +462,24 @@ chinachu.jsonWatcher(
 
 // main
 function main() {
-	clock = new Date().getTime();
-	
-	if (reserves.length !== 0) {
-		reserves.forEach(reservesChecker);
-	} else {
-		next = 0;
+	try {
+		clock = new Date().getTime();
+
+		if (reserves.length !== 0) {
+			reserves.forEach(reservesChecker);
+		} else {
+			next = 0;
+		}
+
+		recording.forEach(recordingChecker);
+
+		if ((scheduler === null) && (clock - scheduled > schedulerIntervalTime) && ((next === 0) || (next - clock > schedulerProcessTime)) && ((schedulerSleepStartHour > new Date().getHours()) || (schedulerSleepEndHour <= new Date().getHours()))) {
+			startScheduler();
+			scheduled = clock;
+		}
 	}
-	
-	recording.forEach(recordingChecker);
-	
-	if ((scheduler === null) && (clock - scheduled > schedulerIntervalTime) && ((next === 0) || (next - clock > schedulerProcessTime)) && ((schedulerSleepStartHour > new Date().getHours()) || (schedulerSleepEndHour <= new Date().getHours()))) {
-		startScheduler();
-		scheduled = clock;
+	catch (e) {
+		util.error('ERROR: ' + e.stack);
 	}
 }
 setInterval(main, 1000);


### PR DESCRIPTION
未ハンドルエラー発生時の処理について2点修正を施しました。
#### 1. upsilon@8ecce73d3f3171a2ed01f4602890a0f42a3cab64

未ハンドルエラーについてログを出力する際に、詳細なスタックトレースを併せて出力するよう修正しました。

``` diff
--- a/app-operator.js
+++ b/app-operator.js
@@ -135,6 +135,8 @@ var scheduled = 0;
 var mainInterval = setInterval(main, 1000); 
 function main() {
        clock = new Date().getTime();
+
+       throw new Error();

        if (reserves.length !== 0) {
                reserves.forEach(reservesChecker);
```

例えば上記のように未ハンドルのエラーを発生させた場合は、次のようなログが `log/operator` に出力されます。

```
uncaughtException: Error
    at main (/home/upsilon/git/Chinachu/app-operator.js:139:7)
    at wrapper [as _onTimeout] (timers.js:252:14)
    at Timer.listOnTimeout [as ontimeout] (timers.js:110:15)
```
#### 2. upsilon@101efacbec62c2635da7c1a09625daf3a193bb4f

`setInterval` によって 1 秒おきに録画の開始・停止やスケジュールの実行を行う `main` 関数内で、予期せず未ハンドルのエラーが発生した場合にそれ以降 `main` 関数が呼ばれなくなる問題があった (#50 でも起きていた) ためこれを修正しました。
