### PR TITLE
CLI: cleanupコマンドのsimulationオプションに対応

### DIFF
--- a/app-cli.js
+++ b/app-cli.js
@@ -796,7 +796,11 @@ function chinachuCleanup() {
 				
 				t.cell('action', 'exist');
 			} else {
-				t.cell('action', 'removed');
+				if (opts.get('simulation')) {
+					t.cell('action', '[simulation] removed');
+				} else {
+					t.cell('action', 'removed');
+				}
 			}
 			
 			t.cell('Program ID', a.id);
@@ -807,7 +811,10 @@ function chinachuCleanup() {
 		
 		return array;
 	})();
-	fs.writeFileSync(RECORDED_DATA_FILE, JSON.stringify(recorded));
+	
+	if (!opts.get('simulation')) {
+		fs.writeFileSync(RECORDED_DATA_FILE, JSON.stringify(recorded));
+	}
 	
 	util.puts(t.print().trim());
 	

--- a/chinachu
+++ b/chinachu
@@ -836,7 +836,7 @@ chinachu_cleanup () {
     read line
     case $line in
       [yY])
-        node app-cli.js -mode cleanup && return 0
+        node app-cli.js -mode cleanup "$@" && return 0
         ;;
       [nN])
         echo "Abort." && return 0


### PR DESCRIPTION
`./chinachu cleanup` で `--simulation` オプションを使用するための修正です。
