### PR TITLE
Scheduler: 0分に終了する番組は前の時間に終わるように解釈する

### DIFF
--- a/app-cli.js
+++ b/app-cli.js
@@ -1016,9 +1016,13 @@ function isMatchedProgram(program) {
 			
 			var progStart = new Date(program.start).getHours();
 			var progEnd   = new Date(program.end).getHours();
+			var progEndMinute = new Date(program.end).getMinutes();
 			
 			if (progStart > progEnd) {
 				progEnd += 24;
+			}
+			if (progEndMinute === 0 ) {
+				progEnd -= 1;
 			}
 			
 			if (ruleStart > ruleEnd) {

--- a/node_modules/chinachu-common/lib/chinachu-common.js
+++ b/node_modules/chinachu-common/lib/chinachu-common.js
@@ -331,9 +331,13 @@ exports.isMatchedProgram = function (rules, program) {
 			
 			var progStart = new Date(program.start).getHours();
 			var progEnd   = new Date(program.end).getHours();
+			var progEndMinute = new Date(program.end).getMinutes();
 			
 			if (progStart > progEnd) {
 				progEnd += 24;
+			}
+			if (progEndMinute === 0 ) {
+				progEnd -= 1;
 			}
 			
 			if (ruleStart > ruleEnd) {


### PR DESCRIPTION
「22時台の番組だけ録りたい」と思い、ルールの開始時間と終了時間を両方とも22時にすると、23時00分00秒で終わる番組が録画できないことに気づきました。
そこで、0分で終わる番組に関しては、直前の時間(この例だと22時台)に終わるように解釈を変更してみました。
よろしくお願いします。
