### PR TITLE
CLI: logrotateコマンド追加

### DIFF
--- a/chinachu
+++ b/chinachu
@@ -868,7 +868,7 @@ chinachu_ircbot () {
 }
 
 chinachu_logrotate () {
-  local cmd name action
+  local cmd action
   action="$1"
   case $action in
     configfile )


### PR DESCRIPTION
#35 の解決策として、CLIにlogrotate(8)用設定ファイルの出力機能を追加しました。

将来、コマンドを叩くとすぐにログをローテートする機能を追加することを想定し、logrotateコマンドを追加して、actionとしてconfigfileを定義する形をとりました。
よろしくお願いします。
