### PR TITLE
CLI: logrotateコマンド追加

### DIFF
--- a/chinachu
+++ b/chinachu
@@ -61,7 +61,7 @@ main () {
     reserve | unreserve | skip | unskip | stop | \
     rule | enrule | disrule | rmrule | \
     rules | reserves | recording | recorded | \
-    cleanup | unlock | ircbot | test )
+    cleanup | unlock | ircbot | logrotate | test )
       cmd="chinachu_$cmd"
       ;;
     * )
@@ -867,6 +867,72 @@ chinachu_ircbot () {
   node app-cli.js -mode ircbot "$@" && return 0
 }
 
+chinachu_logrotate () {
+  local cmd action
+  action="$1"
+  case $action in
+    configfile )
+      cmd="chinachu_logrotate_$action"
+      ;;
+    * )
+      cmd="chinachu_logrotate_help"
+      ;;
+  esac
+  $cmd "$name" && return 0
+}
+
+chinachu_logrotate_configfile () {
+  cat <<EOF
+${CHINACHU_DIR}/log/operator {
+	weekly
+	missingok
+	rotate 13
+	copytruncate
+	ifempty
+}
+
+${CHINACHU_DIR}/log/scheduler {
+	weekly
+	missingok
+	rotate 13
+	copytruncate
+	ifempty
+}
+
+${CHINACHU_DIR}/log/wui {
+	weekly
+	missingok
+	rotate 13
+	copytruncate
+	ifempty
+}
+
+EOF
+  
+  return 0
+}
+
+chinachu_logrotate_help () {
+  cat <<EOF
+
+Usage: ./chinachu logrotate <action>
+
+Actions:
+
+configfile  Output a config file for logrotate(8)
+
+Examples:
+
+# Create a config file and Install to system
+./chinachu logrotate configfile > /tmp/chinachu
+sudo chown root:root /tmp/chinachu
+sudo mv /tmp/chinachu /etc/logrotate.d/
+
+EOF
+
+  return 0
+}
+
 chinachu_test () {
   if [ ! "$1" ]; then
     fail "Usage: test <app> [options]"
@@ -908,6 +974,8 @@ recorded                Show a list of recorded programs.
 cleanup                 Clean-up the recorded list.
 
 ircbot [options]        Connect to IRC server and run a ircbot. (Experimental)
+
+logrotate <action>      Log rotate utility.
 
 test <app> [options]    Run <app> in ${USR_DIR}/bin
 


### PR DESCRIPTION
#35 の解決策として、CLIにlogrotate(8)用設定ファイルの出力機能を追加しました。

将来、コマンドを叩くとすぐにログをローテートする機能を追加することを想定し、logrotateコマンドを追加して、actionとしてconfigfileを定義する形をとりました。
よろしくお願いします。
