### PR TITLE
予約ルール毎に録画開始/終了オフセットを設定できるようにした

### DIFF
--- a/app-operator.js
+++ b/app-operator.js
@@ -216,7 +216,7 @@ function doRecord(program) {
 	
 	util.log('RECORD: ' + dateFormat(new Date(program.start), 'isoDateTime') + ' [' + program.channel.name + '] ' + program.title);
 	
-	timeout = program.end - Date.now() + offsetEnd;
+	timeout = program.end - Date.now() + (typeof program.offsetEnd !== 'undefined' ? program.offsetEnd : offsetEnd);
 	
 	if (timeout < 0) {
 		util.log('FATAL: 時間超過による録画中止');
@@ -379,7 +379,7 @@ function prepRecord(program) {
 	program.isSigTerm = false;
 	recording.push(program);
 	
-	var timeout = program.start - clock - offsetStart;
+	var timeout = program.start - clock - (typeof program.offsetStart !== 'undefined' ? program.offsetStart : offsetStart);
 	if (timeout < 0) { timeout = 3000; }
 	
 	setTimeout(function () {
@@ -438,7 +438,7 @@ function reservesChecker(program, i) {
 // 録画中チェック
 function recordingChecker(program, i) {
 	
-	var timeout = program.end - clock + offsetEnd;
+	var timeout = program.end - clock + (typeof program.offsetEnd !== 'undefined' ? program.offsetEnd : offsetEnd);
 	
 	// 録画時間内はreturn
 	if (timeout >= 0) { return; }

--- a/app-scheduler.js
+++ b/app-scheduler.js
@@ -329,6 +329,14 @@ function scheduler() {
 			if(typeof(rule.recorded_format) !== 'undefined' && chinachu.programMatchesRule(rule, reserve)){
 				reserve.recordedFormat = rule.recorded_format;
 			}
+			if(typeof(rule.offset) !== 'undefined' && chinachu.programMatchesRule(rule, reserve)){
+				if(typeof(rule.offset.start) !== 'undefined'){
+					reserve.offsetStart = rule.offset.start;
+				}
+				if(typeof(rule.offset.end) !== 'undefined'){
+					reserve.offsetEnd = rule.offset.end;
+				}
+			}
 		});
 	});
 	

--- a/web/class.js
+++ b/web/class.js
@@ -1327,6 +1327,26 @@
 									}
 								},
 								{
+									key	: 'offset_start',
+									point   : '/offset/start',
+									label	: '録画開始オフセット(ms)',
+									input	: {
+										type : 'number',
+										style: { width: '80px' },
+										val  : !!rule.offset ? rule.offset.start : void 0
+									}
+								},
+								{
+									key	: 'offset_end',
+									point   : '/offset/end',
+									label	: '録画終了オフセット(ms)',
+									input	: {
+										type : 'number',
+										style: { width: '80px' },
+										val  : !!rule.offset ? rule.offset.end : void 0
+									}
+								},
+								{
 									key   : 'isEnabled',
 									label : 'ルールの状態',
 									input : {
@@ -1358,6 +1378,16 @@
 										}
 										if (!query.duration.min && !query.duration.max) {
 											delete query.duration;
+										}
+
+										if (!query.offset.start) {
+											delete query.offset.start;
+										}
+										if (!query.offset.end) {
+											delete query.offset.end;
+										}
+										if (!query.offset.start && !query.offset.end) {
+											delete query.offset;
 										}
 										
 										var i;
@@ -1558,6 +1588,24 @@
 							input	: {
 								type	: 'text',
 								style	: { width: '100%' },
+							}
+						},
+						{
+							key	: 'offset_start',
+							point   : '/offset/start',
+							label	: '録画開始オフセット(ms)',
+							input	: {
+								type : 'number',
+								style: { width: '80px' }
+							}
+						},
+						{
+							key	: 'offset_end',
+							point   : '/offset/end',
+							label	: '録画終了オフセット(ms)',
+							input	: {
+								type : 'number',
+								style: { width: '80px' }
 							}
 						},
 						{
@@ -1795,6 +1843,24 @@
 							input	: {
 								type	: 'text',
 								style	: { width: '100%' },
+							}
+						},
+						{
+							key	: 'offset_start',
+							point   : '/offset/start',
+							label	: '録画開始オフセット(ms)',
+							input	: {
+								type : 'number',
+								style: { width: '80px' },
+							}
+						},
+						{
+							key	: 'offset_end',
+							point   : '/offset/end',
+							label	: '録画終了オフセット(ms)',
+							input	: {
+								type : 'number',
+								style: { width: '80px' },
 							}
 						},
 						{


### PR DESCRIPTION
たとえば、NHKの番組などでは終了オフセットを放送時間枠いっぱいまで録画したいので、予約ルール毎に録画開始および終了オフセットを設定できるようにしてみました。

今のところルール一覧画面にこの項目を表示するようにまではしていません。
