### PR TITLE
Speed up api/script-scheduler.vm.js

### DIFF
--- a/api/script-scheduler.vm.js
+++ b/api/script-scheduler.vm.js
@@ -31,18 +31,14 @@
 			
 			result.time = fs.statSync(define.SCHEDULER_LOG_FILE).mtime.getTime();
 			
-			var schedulerLog  = child_process.execSync('tail -n $\(tac "' + define.SCHEDULER_LOG_FILE + '" 2>/dev/null | grep -n -m 1 "RUNNING SCHEDULER." | cut -d : -f 1\) "' + define.SCHEDULER_LOG_FILE + '"', {
+			var schedulerLog  = child_process.execSync('/bin/bash -c \'sed "/RUNNING SCHEDULER\\./q" <\(nice -n 19 tac "' + define.SCHEDULER_LOG_FILE + '"\)\' 2>/dev/null', {
 				encoding: 'utf8'
 			});
 			
-			var lines = schedulerLog.split('\n').reverse();
+			var lines = schedulerLog.split('\n');
 			
 			for (var k = 0; k < lines.length; k++) {
 				var line = lines[k] || '';
-				
-				if (line.match('RUNNING SCHEDULER.') !== null) {
-					break;
-				}
 				
 				if ((line.match('CONFLICT:') !== null) || (line.match('RESERVE:') !== null)) {
 					var id = line.match(/(RESERVE|CONFLICT): ([a-z0-9-]+)/)[2];


### PR DESCRIPTION
execSync()内の処理が重くなることがある問題への対処法の一つです。念の為にtacのプロセス優先度もついでに下げてありますが，それでも実用上問題ないことは[下記コメント](https://github.com/kanreisa/Chinachu/compare/devel-beta...tdenc:PR10#commitcomment-13942825)にも書いたとおり確認済みです（さらに良い対処法がありましたら是非コメントください。修正します）。
また，schedulerLogは既にreverseされた文字列が入るので38行目のreverse()は削除し，sedを使うことで最低限の行しか入らないので43〜46行目の処理を削除しました。
