### PR TITLE
convertPrograms関数に対するテストコードを追加

### DIFF
--- a/app-scheduler.js
+++ b/app-scheduler.js
@@ -376,149 +376,6 @@ function scheduler() {
 	process.exit(0);
 }
 
-// (function) program converter
-function convertPrograms(p, ch) {
-	var programs = [];
-	
-	var i, l;
-	for (i = 0, l = p.length; i < l; i++) {
-		var j, m;
-		var c = p[i];
-		
-		if (c.$.channel !== ch.id || !c.title[0]._) {
-			continue;
-		}
-		
-		var title = c.title[0]._;
-		
-		title = title
-			.replace(/【.{1,2}】/g, '')
-			.replace(/\[.\]/g, '')
-			.replace(/[「（#＃♯第]+[0-9０-９零一壱壹弌二弐貮貳三参參弎四肆五伍六陸七柒漆八捌九玖十拾廿卄]+[話回」）]*/g, '');
-		
-		if (c.category[1]._ === 'anime') {
-			title = title.replace(/(?:TV|ＴＶ)?アニメ「([^「」]+)」/g, '$1');
-		}
-		
-		title = title.trim();
-		
-		var desc = c.desc[0]._ || '';
-		
-		var subtitle = '';
-		if (c.title[0]._.match(/[^版]「([^「」]+)」/) !== null) {
-			subtitle = c.title[0]._.match(/[^版]「([^「」]+)」/)[1];
-		} else if (desc.match(/「([^「」]+)」/) !== null) {
-			subtitle = desc.match(/「([^「」]+)」/)[1];
-		} else if (desc.match(/『([^『』]+)』/) !== null) {
-			subtitle = desc.match(/『([^『』]+)』/)[1];
-		}
-		
-		var flags = [];
-		var flagsSource = c.title[0]._
-			.replace(/【/g, '[')
-			.replace(/】/g, ']')
-			.replace(/\[無料\]/g, '[無]');
-		var matchedFlags = (flagsSource.match(/\[(.)\]/g) || []);
-		for (j = 0, m = matchedFlags.length; j < m; j++) {
-			flags.push(matchedFlags[j].match(/(?:【|\[)(.)(?:】|\])/)[1]);
-		}
-		
-		var episodeNumber = null;
-		var episodeNumberMatch = (c.title[0]._ + ' ' + desc).match(/[「（#＃♯第]+[0-9０-９零一壱壹弌二弐貮貳三参參弎四肆五伍六陸七柒漆八捌九玖十拾廿卄]+[話回」）]*|Episode ?[IⅡⅢⅣⅤⅥⅦⅧⅨⅩⅪⅫVX]+/);
-		if (episodeNumberMatch !== null) {
-			var episodeNumberString = episodeNumberMatch[0];
-
-			episodeNumberString = episodeNumberString
-				.replace(/「|（|#|＃|♯|第|話|回|」|）/g, '')
-				.replace(/０|零/g, '0')
-				.replace(/４|Ⅳ|IV|ＩＶ/g, '4')
-				.replace(/８|Ⅷ|VIII|ＶＩＩＩ/g, '8')
-				.replace(/７|Ⅶ|VII|ＶＩＩ/g, '7')
-				.replace(/６|Ⅵ|VI|ＶＩ/g, '6')
-				.replace(/５|Ⅴ/g, '5')
-				.replace(/９|Ⅸ|IX|ＩＸ/g, '9')
-				.replace(/Ⅻ|XII|ＸＩＩ/g, '12')
-				.replace(/Ⅺ|XI|ＸＩ/g, '11')
-				.replace(/３|Ⅲ|III|ＩＩＩ/g, '3')
-				.replace(/２|Ⅱ|II|ＩＩ/g, '2')
-				.replace(/１|Ⅰ|I|Ｉ/g, '1')
-				.replace(/Ⅹ|X|Ｘ/g, '10')
-				.replace(/廿|卄/g, '二十')
-				.replace(/拾/g, '十')
-				.replace(/壱|壹|弌/g, '一')
-				.replace(/弐|貮|貳/g, '二')
-				.replace(/参|參|弎/g, '三')
-				.replace(/肆/g, '四')
-				.replace(/伍/g, '五')
-				.replace(/陸/g, '六')
-				.replace(/柒|漆/g, '七')
-				.replace(/捌/g, '八')
-				.replace(/玖/g, '九')
-				.replace(/二十一/g, '21')
-				.replace(/二十二/g, '22')
-				.replace(/二十三/g, '23')
-				.replace(/二十四/g, '24')
-				.replace(/二十/g, '20')
-				.replace(/十一/g, '11')
-				.replace(/十二/g, '12')
-				.replace(/十三/g, '13')
-				.replace(/十四/g, '14')
-				.replace(/十五/g, '15')
-				.replace(/十六/g, '16')
-				.replace(/十七/g, '17')
-				.replace(/十八/g, '18')
-				.replace(/十九/g, '19')
-				.replace(/十/g, '10')
-				.replace(/一/g, '1')
-				.replace(/二/g, '2')
-				.replace(/三/g, '3')
-				.replace(/四/g, '4')
-				.replace(/五/g, '5')
-				.replace(/六/g, '6')
-				.replace(/七/g, '7')
-				.replace(/八/g, '8')
-				.replace(/九/g, '9')
-				.trim();
-
-			episodeNumber = parseInt(episodeNumberString, 10);
-		}
-		if (episodeNumber === null && flags.indexOf('新') !== -1) {
-			episodeNumber = 1;
-		}
-		
-		var tcRegex   = /^(.{4})(.{2})(.{2})(.{2})(.{2})(.{2}).+$/;
-		var startDate = new Date(c.$.start.replace(tcRegex, '$1/$2/$3 $4:$5:$6'));
-		var endDate   = new Date(c.$.stop.replace(tcRegex, '$1/$2/$3 $4:$5:$6'));
-		var startTime = startDate.getTime();
-		var endTime   = endDate.getTime();
-		
-		// 番組ID (v1.3)
-		var programId = '';
-		programId += ch.id.toLowerCase().replace('_', '');
-		programId += '-';
-		programId += parseInt(c.$.event_id, 10).toString(36);
-		
-		var programData = {
-			id        : programId,
-			channel   : ch,
-			category  : c.category[1]._,
-			title     : title,
-			subTitle  : subtitle,
-			fullTitle : c.title[0]._,
-			detail    : desc,
-			episode   : episodeNumber,
-			start     : startTime,
-			end       : endTime,
-			seconds   : ((endTime - startTime) / 1000),
-			flags     : flags
-		};
-		
-		programs.push(programData);
-	}
-	
-	return programs;
-}
-
 // EPGデータを取得
 function getEpg() {
 	
@@ -733,7 +590,7 @@ function getEpg() {
 									sid    : a.service_id[0]
 								};
 								
-								ch.programs = convertPrograms(result.tv.programme, JSON.parse(JSON.stringify(ch)));
+								ch.programs = chinachu.convertPrograms(result.tv.programme, JSON.parse(JSON.stringify(ch)));
 								
 								s.forEach(function (c) {
 									c.programs.forEach(function (p) {
@@ -788,7 +645,7 @@ function getEpg() {
 									sid    : a.service_id[0]
 								};
 								
-								ch.programs = convertPrograms(result.tv.programme, JSON.parse(JSON.stringify(ch)));
+								ch.programs = chinachu.convertPrograms(result.tv.programme, JSON.parse(JSON.stringify(ch)));
 								
 								s.push(ch);
 								
@@ -828,7 +685,7 @@ function getEpg() {
 									sid    : a.service_id[0]
 								};
 								
-								ch.programs = convertPrograms(result.tv.programme, JSON.parse(JSON.stringify(ch)));
+								ch.programs = chinachu.convertPrograms(result.tv.programme, JSON.parse(JSON.stringify(ch)));
 								
 								s.push(ch);
 								
@@ -868,7 +725,7 @@ function getEpg() {
 									sid    : a.service_id[0]
 								};
 								
-								ch.programs = convertPrograms(result.tv.programme, JSON.parse(JSON.stringify(ch)));
+								ch.programs = chinachu.convertPrograms(result.tv.programme, JSON.parse(JSON.stringify(ch)));
 								
 								s.push(ch);
 								

--- a/node_modules/chinachu-common/lib/chinachu-common.js
+++ b/node_modules/chinachu-common/lib/chinachu-common.js
@@ -562,8 +562,8 @@ exports.convertPrograms = function (p, ch) {
 		var desc = c.desc[0]._ || '';
 
 		var subtitle = '';
-		if (c.title[0]._.match(/[^版]「([^「」]+)」/) !== null) {
-			subtitle = c.title[0]._.match(/[^版]「([^「」]+)」/)[1];
+		if (title.match(/[^版]「([^「」]+)」/) !== null) {
+			subtitle = title.match(/[^版]「([^「」]+)」/)[1];
 		} else if (desc.match(/「([^「」]+)」/) !== null) {
 			subtitle = desc.match(/「([^「」]+)」/)[1];
 		} else if (desc.match(/『([^『』]+)』/) !== null) {

--- a/node_modules/chinachu-common/lib/chinachu-common.js
+++ b/node_modules/chinachu-common/lib/chinachu-common.js
@@ -532,3 +532,146 @@ exports.programMatchesRule = function (rule, program, nf, fullTitle_norm, detail
 
 	return true;
 };
+
+// (function) program converter
+exports.convertPrograms = function (p, ch) {
+	var programs = [];
+
+	var i, l;
+	for (i = 0, l = p.length; i < l; i++) {
+		var j, m;
+		var c = p[i];
+
+		if (c.$.channel !== ch.id || !c.title[0]._) {
+			continue;
+		}
+
+		var title = c.title[0]._;
+
+		title = title
+			.replace(/【.{1,2}】/g, '')
+			.replace(/\[.\]/g, '')
+			.replace(/[「（#＃♯第]+[0-9０-９零一壱壹弌二弐貮貳三参參弎四肆五伍六陸七柒漆八捌九玖十拾廿卄]+[話回」）]*/g, '');
+
+		if (c.category[1]._ === 'anime') {
+			title = title.replace(/(?:TV|ＴＶ)?アニメ「([^「」]+)」/g, '$1');
+		}
+
+		title = title.trim();
+
+		var desc = c.desc[0]._ || '';
+
+		var subtitle = '';
+		if (c.title[0]._.match(/[^版]「([^「」]+)」/) !== null) {
+			subtitle = c.title[0]._.match(/[^版]「([^「」]+)」/)[1];
+		} else if (desc.match(/「([^「」]+)」/) !== null) {
+			subtitle = desc.match(/「([^「」]+)」/)[1];
+		} else if (desc.match(/『([^『』]+)』/) !== null) {
+			subtitle = desc.match(/『([^『』]+)』/)[1];
+		}
+
+		var flags = [];
+		var flagsSource = c.title[0]._
+			.replace(/【/g, '[')
+			.replace(/】/g, ']')
+			.replace(/\[無料\]/g, '[無]');
+		var matchedFlags = (flagsSource.match(/\[(.)\]/g) || []);
+		for (j = 0, m = matchedFlags.length; j < m; j++) {
+			flags.push(matchedFlags[j].match(/(?:【|\[)(.)(?:】|\])/)[1]);
+		}
+
+		var episodeNumber = null;
+		var episodeNumberMatch = (c.title[0]._ + ' ' + desc).match(/[「（#＃♯第]+[0-9０-９零一壱壹弌二弐貮貳三参參弎四肆五伍六陸七柒漆八捌九玖十拾廿卄]+[話回」）]*|Episode ?[IⅡⅢⅣⅤⅥⅦⅧⅨⅩⅪⅫVX]+/);
+		if (episodeNumberMatch !== null) {
+			var episodeNumberString = episodeNumberMatch[0];
+
+			episodeNumberString = episodeNumberString
+				.replace(/「|（|#|＃|♯|第|話|回|」|）/g, '')
+				.replace(/０|零/g, '0')
+				.replace(/４|Ⅳ|IV|ＩＶ/g, '4')
+				.replace(/８|Ⅷ|VIII|ＶＩＩＩ/g, '8')
+				.replace(/７|Ⅶ|VII|ＶＩＩ/g, '7')
+				.replace(/６|Ⅵ|VI|ＶＩ/g, '6')
+				.replace(/５|Ⅴ/g, '5')
+				.replace(/９|Ⅸ|IX|ＩＸ/g, '9')
+				.replace(/Ⅻ|XII|ＸＩＩ/g, '12')
+				.replace(/Ⅺ|XI|ＸＩ/g, '11')
+				.replace(/３|Ⅲ|III|ＩＩＩ/g, '3')
+				.replace(/２|Ⅱ|II|ＩＩ/g, '2')
+				.replace(/１|Ⅰ|I|Ｉ/g, '1')
+				.replace(/Ⅹ|X|Ｘ/g, '10')
+				.replace(/廿|卄/g, '二十')
+				.replace(/拾/g, '十')
+				.replace(/壱|壹|弌/g, '一')
+				.replace(/弐|貮|貳/g, '二')
+				.replace(/参|參|弎/g, '三')
+				.replace(/肆/g, '四')
+				.replace(/伍/g, '五')
+				.replace(/陸/g, '六')
+				.replace(/柒|漆/g, '七')
+				.replace(/捌/g, '八')
+				.replace(/玖/g, '九')
+				.replace(/二十一/g, '21')
+				.replace(/二十二/g, '22')
+				.replace(/二十三/g, '23')
+				.replace(/二十四/g, '24')
+				.replace(/二十/g, '20')
+				.replace(/十一/g, '11')
+				.replace(/十二/g, '12')
+				.replace(/十三/g, '13')
+				.replace(/十四/g, '14')
+				.replace(/十五/g, '15')
+				.replace(/十六/g, '16')
+				.replace(/十七/g, '17')
+				.replace(/十八/g, '18')
+				.replace(/十九/g, '19')
+				.replace(/十/g, '10')
+				.replace(/一/g, '1')
+				.replace(/二/g, '2')
+				.replace(/三/g, '3')
+				.replace(/四/g, '4')
+				.replace(/五/g, '5')
+				.replace(/六/g, '6')
+				.replace(/七/g, '7')
+				.replace(/八/g, '8')
+				.replace(/九/g, '9')
+				.trim();
+
+			episodeNumber = parseInt(episodeNumberString, 10);
+		}
+		if (episodeNumber === null && flags.indexOf('新') !== -1) {
+			episodeNumber = 1;
+		}
+
+		var tcRegex   = /^(.{4})(.{2})(.{2})(.{2})(.{2})(.{2}).+$/;
+		var startDate = new Date(c.$.start.replace(tcRegex, '$1/$2/$3 $4:$5:$6'));
+		var endDate   = new Date(c.$.stop.replace(tcRegex, '$1/$2/$3 $4:$5:$6'));
+		var startTime = startDate.getTime();
+		var endTime   = endDate.getTime();
+
+		// 番組ID (v1.3)
+		var programId = '';
+		programId += ch.id.toLowerCase().replace('_', '');
+		programId += '-';
+		programId += parseInt(c.$.event_id, 10).toString(36);
+
+		var programData = {
+			id        : programId,
+			channel   : ch,
+			category  : c.category[1]._,
+			title     : title,
+			subTitle  : subtitle,
+			fullTitle : c.title[0]._,
+			detail    : desc,
+			episode   : episodeNumber,
+			start     : startTime,
+			end       : endTime,
+			seconds   : ((endTime - startTime) / 1000),
+			flags     : flags
+		};
+
+		programs.push(programData);
+	}
+
+	return programs;
+};

--- a/test/module.chinachu-common.program.js
+++ b/test/module.chinachu-common.program.js
@@ -1,0 +1,298 @@
+'use strict';
+
+var should = require('should');
+var chinachu = require('chinachu-common');
+
+describe('convertPrograms', function() {
+	// この番組情報を元にテストデータを作成する
+	var baseProgram = {
+		$: { start: '20150101000000 +0900', stop: '20150101003000 +0900', channel: 'GR_11111', event_id: '12345' },
+		title: [
+			{ $: { lang: 'ja_JP' }, _: 'タイトル' },
+		],
+		desc: [
+			{ $: { lang: 'ja_JP' }, _: '説明文' },
+		],
+		category: [
+			{ $: { lang: 'ja_JP' },  _: 'アニメ／特撮' },
+			{ $: { lang: 'en' },  _: 'anime' },
+		],
+	};
+	var ch = {
+		type: 'GR',
+		channel: '11',
+		name: '放送局名',
+		id: 'GR_11111',
+		sid: '10000',
+	};
+
+	function clone(obj) {
+		return JSON.parse(JSON.stringify(obj));
+	}
+
+	it('番組情報をパースする', function() {
+        var c = clone(baseProgram);
+
+        var programs = chinachu.convertPrograms([c], ch);
+
+		should.deepEqual(programs[0], {
+			id: 'gr11111-9ix',
+			channel: {
+				type: 'GR',
+				channel: '11',
+				name: '放送局名',
+				id: 'GR_11111',
+				sid: '10000',
+			},
+			category: 'anime',
+			title: 'タイトル',
+			subTitle: '',
+			fullTitle: 'タイトル',
+			detail: '説明文',
+			episode: null,
+			start: new Date('2015-01-01 00:00:00').getTime(),
+			end: new Date('2015-01-01 00:30:00').getTime(),
+			seconds: 30 * 60,
+			flags: [],
+		});
+	});
+
+	function parseEpisodeNumber(episodeNumberStr) {
+		var c = clone(baseProgram);
+		c.desc = [
+			{ $: { lang: 'ja_JP' }, _: episodeNumberStr },
+		];
+
+		var programs = chinachu.convertPrograms([c], ch);
+		return programs[0].episode;
+	}
+
+	describe('話数のパース', function() {
+		it('算用数字をパースする', function() {
+			var testPatterns = [
+				['＃０', 0], ['＃１', 1], ['＃２', 2], ['＃３', 3], ['＃４', 4],
+				['＃５', 5], ['＃６', 6], ['＃７', 7], ['＃８', 8], ['＃９', 9],
+
+				['＃００', 0], ['＃０１', 1], ['＃０２', 2], ['＃０３', 3], ['＃０４', 4],
+				['＃０５', 5], ['＃０６', 6], ['＃０７', 7], ['＃０８', 8], ['＃０９', 9],
+				['＃１０', 10], ['＃１１', 11], ['＃１２', 12], ['＃１３', 13], ['＃１４', 14],
+				['＃１５', 15], ['＃１６', 16], ['＃１７', 17], ['＃１８', 18], ['＃１９', 19],
+				['＃２０', 20], ['＃２１', 21], ['＃２２', 22], ['＃２３', 23], ['＃２４', 24],
+
+				['#1', 1], ['#01', 1], ['♯1', 1], ['♯01', 1],
+				['第1回', 1], ['第１回', 1], ['第1話', 1], ['第１話', 1],
+			];
+
+			testPatterns.forEach(function(pattern) {
+				var episodeNumberStr = pattern[0];
+				var expected = pattern[1];
+
+				should.strictEqual(parseEpisodeNumber(episodeNumberStr), expected, episodeNumberStr);
+			});
+		});
+
+		it('漢数字をパースする', function() {
+			var testPatterns = [
+				['第零話', 0],
+				['第一話', 1], ['第壱話', 1], ['第壹話', 1], ['第弌話', 1],
+				['第二話', 2], ['第弐話', 2], ['第貮話', 2], ['第貳話', 2],
+				['第三話', 3], ['第参話', 3], ['第參話', 3], ['第弎話', 3],
+				['第四話', 4], ['第肆話', 4],
+				['第五話', 5], ['第伍話', 5],
+				['第六話', 6], ['第陸話', 6],
+				['第七話', 7], ['第柒話', 7], ['第漆話', 7],
+				['第八話', 8], ['第捌話', 8],
+				['第九話', 9], ['第玖話', 9],
+
+				['第十話', 10], ['第十一話', 11], ['第十二話', 12], ['第十三話', 13], ['第十四話', 14],
+				['第十五話', 15], ['第十六話', 16], ['第十七話', 17], ['第十八話', 18], ['第十九話', 19],
+				['第二十話', 20], ['第二十一話', 21], ['第二十二話', 22], ['第二十三話', 23], ['第二十四話', 24],
+
+				// 「十」を含まないパターン
+				['第二一話', 21], ['第二二話', 22], ['第二三話', 23], ['第二四話', 24],
+
+				// 大字 (Issue #246)
+				// 10 話以上の話数で 壱, 弐, 参, 伍, 拾 以外の大字を使う作品は見つからなかったので考慮していない
+				['第拾話', 10], ['第拾壱話', 11], ['第拾弐話', 12], ['第壱参話', 13], ['第壱四話', 14],
+				['第壱伍話', 15], ['第壱六話', 16], ['第壱七話', 17], ['第壱八話', 18], ['第壱九話', 19],
+				['第弐拾話', 20], ['第弐拾壱話', 21], ['第弐拾弐話', 22], ['第弐拾参話', 23], ['第弐拾四話', 24],
+			];
+
+			testPatterns.forEach(function(pattern) {
+				var episodeNumberStr = pattern[0];
+				var expected = pattern[1];
+
+				should.strictEqual(parseEpisodeNumber(episodeNumberStr), expected, episodeNumberStr);
+			});
+		});
+
+		// Issue #242
+		it('タイトル（第ｎ話）の形式の話数をパースする', function() {
+			var c = clone(baseProgram);
+			c.title = [
+				{ $: { lang: 'ja_JP' }, _: 'タイトル（第１０話）' },
+			];
+
+			var programs = chinachu.convertPrograms([c], ch);
+			should.strictEqual(programs[0].title, 'タイトル');
+			should.strictEqual(programs[0].episode, 10);
+		});
+
+		// Issue #242
+		it('タイトル（ｎ）の形式の話数をパースする', function() {
+			var c = clone(baseProgram);
+			c.title = [
+				{ $: { lang: 'ja_JP' }, _: 'タイトル（１０）' },
+			];
+
+			var programs = chinachu.convertPrograms([c], ch);
+			should.strictEqual(programs[0].title, 'タイトル');
+			should.strictEqual(programs[0].episode, 10);
+		});
+
+		// Issue #242
+		it('タイトル「ｎ話」の形式の話数をパースする', function() {
+			var c = clone(baseProgram);
+			c.title = [
+				{ $: { lang: 'ja_JP' }, _: 'タイトル「１０話」' },
+			];
+
+			var programs = chinachu.convertPrograms([c], ch);
+			should.strictEqual(programs[0].title, 'タイトル');
+			should.strictEqual(programs[0].episode, 10);
+		});
+	});
+
+	context('title に話数とサブタイトルが含まれている場合', function() {
+		var c = clone(baseProgram);
+		c.title = [
+			{ $: { lang: 'ja_JP' }, _: 'タイトル　＃１「サブタイトル」' },
+		];
+		c.desc = [
+			{ $: { lang: 'ja_JP' }, _: '' },
+		];
+
+		var programs = chinachu.convertPrograms([c], ch);
+
+		it('episode には title から抽出した話数が入る', function() {
+			should.strictEqual(programs[0].episode, 1);
+		});
+		it('subTitle には title から抽出したサブタイトルが入る', function() {
+			should.strictEqual(programs[0].subTitle, 'サブタイトル');
+		});
+		it('title から話数を除去し、サブタイトルは残す', function() {
+			should.strictEqual(programs[0].title, 'タイトル　「サブタイトル」');
+		});
+	});
+
+	context('title に話数が、desc にサブタイトルが含まれている場合', function() {
+		var c = clone(baseProgram);
+		c.title = [
+			{ $: { lang: 'ja_JP' }, _: 'タイトル　＃１' },
+		];
+		c.desc = [
+			{ $: { lang: 'ja_JP' }, _: '「サブタイトル」' },
+		];
+
+		var programs = chinachu.convertPrograms([c], ch);
+
+		it('episode には title から抽出した話数が入る', function() {
+			should.strictEqual(programs[0].episode, 1);
+		});
+		it('subTitle には desc から抽出したサブタイトルが入る', function() {
+			should.strictEqual(programs[0].subTitle, 'サブタイトル');
+		});
+		it('title から話数を除去する', function() {
+			should.strictEqual(programs[0].title, 'タイトル');
+		});
+	});
+
+	context('desc に話数とサブタイトルが含まれている場合', function() {
+		var c = clone(baseProgram);
+		c.title = [
+			{ $: { lang: 'ja_JP' }, _: 'タイトル' },
+		];
+		c.desc = [
+			{ $: { lang: 'ja_JP' }, _: '＃１「サブタイトル」' },
+		];
+
+		var programs = chinachu.convertPrograms([c], ch);
+
+		it('episode には desc から抽出した話数が入る', function() {
+			should.strictEqual(programs[0].episode, 1);
+		});
+		it('subTitle には desc から抽出したサブタイトルが入る', function() {
+			should.strictEqual(programs[0].subTitle, 'サブタイトル');
+		});
+		it('title は変化しない', function() {
+			should.strictEqual(programs[0].title, 'タイトル');
+		});
+	});
+
+	describe('サブタイトル誤爆対策', function() {
+		// Issue #184
+		context('TVアニメ「〜」', function() {
+			var c = clone(baseProgram);
+			c.title = [
+				{ $: { lang: 'ja_JP' }, _: 'TVアニメ「アニメのタイトル」' },
+			];
+			c.desc = [
+				{ $: { lang: 'ja_JP' }, _: '＃１「サブタイトル」' },
+			];
+
+			var programs = chinachu.convertPrograms([c], ch);
+
+			it('「TVアニメ」をタイトルに含めない', function() {
+				should.strictEqual(programs[0].title, 'アニメのタイトル');
+			});
+			it('desc にサブタイトルや話数があればそれを使う', function() {
+				should.strictEqual(programs[0].subTitle, 'サブタイトル');
+				should.strictEqual(programs[0].episode, 1);
+			});
+		});
+
+		// Issue #28
+		context('劇場版「〜」', function() {
+			var c = clone(baseProgram);
+			c.title = [
+				{ $: { lang: 'ja_JP' }, _: '劇場版「魔女っ娘ミラクるん」' },
+			];
+			c.desc = [
+				{ $: { lang: 'ja_JP' }, _: '＃１「サブタイトル」' },
+			];
+
+			var programs = chinachu.convertPrograms([c], ch);
+
+			it('劇場版とその後に続く鉤括弧の内容も含めてタイトルとして扱う', function() {
+				should.strictEqual(programs[0].title, '劇場版「魔女っ娘ミラクるん」');
+			});
+			it('desc にサブタイトルや話数があればそれを使う', function() {
+				should.strictEqual(programs[0].subTitle, 'サブタイトル');
+				should.strictEqual(programs[0].episode, 1);
+			});
+		});
+
+		// Issue #242
+		context('タイトル「１０話」', function() {
+			var c = clone(baseProgram);
+			c.title = [
+				{ $: { lang: 'ja_JP' }, _: 'タイトル「１０話」' },
+			];
+			c.desc = [
+				{ $: { lang: 'ja_JP' }, _: '「サブタイトル」' },
+			];
+
+			var programs = chinachu.convertPrograms([c], ch);
+
+			it('「１０話」の部分はタイトルに含めない', function() {
+				should.strictEqual(programs[0].title, 'タイトル');
+			});
+			it('「１０話」の部分は話数として扱う', function() {
+				should.strictEqual(programs[0].episode, 10);
+			});
+			it('desc にサブタイトルがあればそれを使う', function() {
+				should.strictEqual(programs[0].subTitle, 'サブタイトル');
+			});
+		});
+	});
+});


### PR DESCRIPTION
convertPrograms 関数の、特にタイトル・サブタイトルおよび話数の抽出処理に対するテストコードを追加しました。

タイトル等の抽出処理は、放送局ごとのクセや作品ごとの独特な表記などに対応するため変更頻度が比較的高い箇所となっています。
しかし同時に、この関数によるタイトルの抽出結果が変化することはユーザーが設定する録画予約ルールに大きな影響を与えるため、少なくともこれらのテストコードにより動作確認されることが望ましいと考えます。

テストコードには下記のコミット及び Issue 等に相当するパターンが含まれています:
- 77699747: `#1` `＃１` `♯１` `第1話` `第一話` `タイトル「サブタイトル」`
- #28: `劇場版「タイトル」`
- #184: `TVアニメ「タイトル」`
- #242: `タイトル（第○○話）` `タイトル（○○）` `タイトル「第○○話」` （`○○` は話数）
- #246: `第壱話`
