### PR TITLE
アニメイズム枠タイトル抽出の修正

### DIFF
--- a/app-scheduler.js
+++ b/app-scheduler.js
@@ -397,7 +397,7 @@ function convertPrograms(p, ch) {
 			.replace(/[「（#＃♯第]+[0-9０-９零一壱壹弌二弐貮貳三参參弎四肆五伍六陸七柒漆八捌九玖十拾廿卄]+[話回」）]*/g, '');
 		
 		if (c.category[1]._ === 'anime') {
-			title = title.replace(/(?:TV|ＴＶ)?アニメ「([^「」]+)」/g, '$1')
+			title = title.replace(/(?:TV|ＴＶ)?アニメ(?:イズム)?「([^「」]+)」/g, '$1')
 				.replace(/([^場版])「.+」/g, '$1');
 		}
 		


### PR DESCRIPTION
些細なFIXですが、関西地方ＭＢＳ毎日放送のアニメイズム枠EPGタイトルから正しいタイトルを取得する為の修正です。
修正前は以下のようにタイトルが抽出されていました。

完全なタイトル: アニメイズム「迷家ーマヨイガー」　＃０５「ユウナ３人いると紛らわしい」
title: 'アニメイズム', subtitle: '迷家ーマヨイガー'
