### PR TITLE
Fix: Travis badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Chinachu [![Build Status](https://secure.travis-ci.org/kanreisa/Chinachu.png)](http://travis-ci.org/kanreisa/Chinachu) [![tip for next commit](http://tip4commit.com/projects/689.svg)](http://tip4commit.com/projects/689)
+Chinachu [![Build Status](https://secure.travis-ci.org/Chinachu/Chinachu.svg)](http://travis-ci.org/Chinachu/Chinachu) [![tip for next commit](http://tip4commit.com/projects/689.svg)](http://tip4commit.com/projects/689)
 ========
 
 Visit the Chinachu website for more information: <https://chinachu.moe/>


### PR DESCRIPTION
Readme.mdのTravis badgeのURLが現在のものと違いましたので、修正しました。