### PR TITLE
番組タイトルの話数前後に【】が含まれる場合への対応

### DIFF
--- a/app-scheduler.js
+++ b/app-scheduler.js
@@ -394,7 +394,7 @@ function convertPrograms(p, ch) {
 		title = title
 			.replace(/【.{1,2}】/g, '')
 			.replace(/\[.\]/g, '')
-			.replace(/【?[「（#＃♯第]+[0-9０-９零一壱壹弌二弐貮貳三参參弎四肆五伍六陸七柒漆八捌九玖十拾廿卄]+[話回」）]*】?/g, '');
+			.replace(/[【「（#＃♯第]+[0-9０-９零一壱壹弌二弐貮貳三参參弎四肆五伍六陸七柒漆八捌九玖十拾廿卄]+[話回】」）]*/g, '');
 		
 		if (c.category[1]._ === 'anime') {
 			title = title.replace(/(?:TV|ＴＶ)?アニメ(?:イズム)?「([^「」]+)」/g, '$1')

--- a/app-scheduler.js
+++ b/app-scheduler.js
@@ -394,7 +394,7 @@ function convertPrograms(p, ch) {
 		title = title
 			.replace(/【.{1,2}】/g, '')
 			.replace(/\[.\]/g, '')
-			.replace(/[「（#＃♯第]+[0-9０-９零一壱壹弌二弐貮貳三参參弎四肆五伍六陸七柒漆八捌九玖十拾廿卄]+[話回」）]*/g, '');
+			.replace(/【?[「（#＃♯第]+[0-9０-９零一壱壹弌二弐貮貳三参參弎四肆五伍六陸七柒漆八捌九玖十拾廿卄]+[話回」）]*】?/g, '');
 		
 		if (c.category[1]._ === 'anime') {
 			title = title.replace(/(?:TV|ＴＶ)?アニメ(?:イズム)?「([^「」]+)」/g, '$1')


### PR DESCRIPTION
EPGで取得する番組タイトルに、話数が 【第n話】 などで含まれている場合に
Chinachu番組表の番組タイトルでは 【】 が残ってしまっていたため、
正規表現を追加して、 【】 を含めて取り除くよう対応しました。

完全なタイトル: [新]ドラマ２４　勇者ヨシヒコと導かれし七人【第１話】[字][デ]
対応前タイトル: ドラマ２４　勇者ヨシヒコと導かれし七人【】
対応後タイトル: ドラマ２４　勇者ヨシヒコと導かれし七人
