### PR TITLE
Update to socket.io 1.x

### DIFF
--- a/app-wui.js
+++ b/app-wui.js
@@ -721,9 +721,7 @@ function iosAddEventListner(io, eventName) {
 function ioAddListener(server, isOpen) {
 	var io = socketio.listen(server);
 
-	io.enable('browser client minification');
-	io.set('log level', 1);
-	io.set('transports', ['websocket', 'flashsocket', 'htmlfile', 'xhr-polling', 'jsonp-polling']);
+	io.set('transports', ['polling', 'websocket', 'flashsocket', 'htmlfile', 'xhr-polling', 'jsonp-polling']);
 	io.sockets.on('connection', isOpen ? ioOpenServer : ioServer);
 
 	// listen event

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "mkdirp": "~0.3.5",
     "mtwitter": "~1.5.2",
     "opts": "~1.2.2",
-    "socket.io": "~0.9.16",
+    "socket.io": "~1.4.5",
     "string": "~1.5.1",
     "swagger-client": "github:kanreisa/swagger-js#feature/unix-domain-socket",
     "xml2js": "~0.2.8"


### PR DESCRIPTION
0.9.x is broken with newer versions of node.js.