### PR TITLE
Travis CIのビルドがコケるのを修正

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,15 @@
 language: node_js
+
 node_js:
   - "6.9.1"
+
+
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8
 
 before_install:
   - wget http://www.tortall.net/projects/yasm/releases/yasm-1.3.0.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,9 @@ addons:
     packages:
       - g++-4.8
 
+env:
+  - CXX=g++-4.8
+
 before_install:
   - wget http://www.tortall.net/projects/yasm/releases/yasm-1.3.0.tar.gz
   - tar xvzf yasm-1.3.0.tar.gz && cd yasm*


### PR DESCRIPTION
g++を用意してCXXを設定

参照：https://docs.travis-ci.com/user/languages/javascript-with-nodejs#Node.js-v4-(or-io.js-v3)-compiler-requirements