### PR TITLE
放送日時の末尾に曜日を追加する

### DIFF
--- a/web/class.js
+++ b/web/class.js
@@ -108,7 +108,10 @@
 				}
 			}
 		}
-
+		
+		var weekDays = ["日", "月", "火", "水", "木", "金", "土"];
+		dStr += " [" + weekDays[d.getDay()] + "]";
+		
 		if (typeof type === 'undefined' || type === 'full') {
 			return dStr + ' (' + dDeltaStr + ')';
 		} else if (type === 'short') {


### PR DESCRIPTION
「予約済」「録画中」「録画済」の放送日時の末尾に曜日を追加してみました。
検討よろしくお願いします。

![Yabumi](https://yabumi.cc/15936da3d7d32d9c313f1dc8.png)
