### PR TITLE
WUI: socket.ioを1.x系にアップグレード

### DIFF
--- a/app-wui.js
+++ b/app-wui.js
@@ -743,17 +743,14 @@ function iosAddEventListner(io, eventName) {
 		for (i = 0, l = arguments.length; i < l; i++) {
 			args.push(arguments[i]);
 		}
-		io.sockets.emit.apply(io.sockets, [eventName].concat(args));
+		io.emit.apply(io, [eventName].concat(args));
 	});
 }
 
 function ioAddListener(server, isOpen) {
-	var io = socketio.listen(server);
+	var io = socketio(server);
 
-	io.enable('browser client minification');
-	io.set('log level', 1);
-	io.set('transports', ['websocket', 'flashsocket', 'htmlfile', 'xhr-polling', 'jsonp-polling']);
-	io.sockets.on('connection', isOpen ? ioOpenServer : ioServer);
+	io.on('connection', isOpen ? ioOpenServer : ioServer);
 
 	// listen event
 	iosAddEventListner(io, 'status');

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "nodemailer": "^2.7.0",
     "nodemailer-sendmail-transport": "^1.0.0",
     "opts": "~1.2.2",
-    "socket.io": "~0.9.16",
+    "socket.io": "^1.7.2",
     "string": "~1.5.1",
     "swagger-client": "github:kanreisa/swagger-js#feature/unix-domain-socket",
     "xml2js": "~0.2.8"


### PR DESCRIPTION
わたしの環境の問題かもしれないのですが、最近Google ChromeをアップデートしたタイミングでGoogle ChromeでのみChinachuでWebSocketの接続に失敗するようになってしまいました。

socket.io v1.x系では初めにlong pollingで接続をしておいて、後からWebSocketでの接続を試みて接続に成功したらlong pollingをやめてWebSocketに置き換えるという仕様になっています。v0.9以前では最初にWeb Socketで接続しようとし、失敗したらほかの手段を試すという仕様になっていました。そのためWeb Socketでの接続に失敗するような環境ではsocket.ioの接続が通るまで時間がかかってしまいます。

Chinachuではsocket.io v0.9が使われているため、同様にWebSocketの接続に失敗するとlong pollingに置き換わるまでの間、ローディング表示がずっと出てしまっていました。これは初回読み込み時にのみ起こることではあり、リロードしない限りは気になるようなものではありませんが、少し不便です。

なのでsocket.ioをv1.x系にアップグレードしてみました。お手間をかけてしまいますが、ご確認ください。

なんらかの意図があってv0.9のままにしていたのでしたら、Closeしてくださって構いません。