### PR TITLE
socket.io 1.x系でのオプションフォーマット変更に追従

### DIFF
--- a/web/chinachu.js
+++ b/web/chinachu.js
@@ -33,7 +33,7 @@
 
 	app.socket = io.connect(window.location.protocol + '//' + window.location.host, {
 		connectTimeout: 3000,
-		resource: window.location.pathname.replace(/^\/|[^\/]*$/g, '') + 'socket.io',
+		path: window.location.pathname.replace(/[^\/]*$/g, '') + 'socket.io',
 	});
 
 	// コントロールビュー初期化


### PR DESCRIPTION
socket.io v1.xにて、resource オプション名とフォーマットが変更されていました。
http://socket.io/docs/migrating-from-0-9/
のSetting resource pathの項目の内容になります。この変更の追従になります。
(reverse proxyを通していたので、この変更がないとWUIに正常にアクセスできませんでした)

ご確認よろしくお願いします。