### PR TITLE
`./chinachu updater`で走るinstallerのオプションをfastからfullに変更

### DIFF
--- a/chinachu
+++ b/chinachu
@@ -249,11 +249,11 @@ chinachu_updater_main () {
   git gc
   
   while [ 1 ]; do
-    echo -n "Do you want to run chinachu installer (fast) [Y/n]? "
+    echo -n "Do you want to run chinachu installer (full) [Y/n]? "
     read line
     case ${line:-y} in
       [yY])
-        echo 2 | ./chinachu installer
+        echo 1 | ./chinachu installer
         break
         ;;
       [nN])


### PR DESCRIPTION
Node Modules関連の更新が入った際（直近では 7e5f375 のようなcommit），`./chinachu updater`経由で走る`./chinachu installer`のデフォルトオプションがfastであるためにNode Modulesが更新されない問題への対処です。
fullにしないほうがよい理由などがありましたらrejectして頂いて構いません :)