### PR TITLE
Androidから再生する際にVLCを起動する

### DIFF
--- a/web/lib/prototype.js
+++ b/web/lib/prototype.js
@@ -18,7 +18,8 @@ var Prototype = {
       Opera:          isOpera,
       WebKit:         ua.indexOf('AppleWebKit/') > -1,
       Gecko:          ua.indexOf('Gecko') > -1 && ua.indexOf('KHTML') === -1,
-      MobileSafari:   /Apple.*Mobile/.test(ua)
+      MobileSafari:   /Apple.*Mobile/.test(ua),
+      Android:        ua.indexOf('Linux; Android') > -1
     }
   })(),
 

--- a/web/lib/prototype.js
+++ b/web/lib/prototype.js
@@ -18,8 +18,7 @@ var Prototype = {
       Opera:          isOpera,
       WebKit:         ua.indexOf('AppleWebKit/') > -1,
       Gecko:          ua.indexOf('Gecko') > -1 && ua.indexOf('KHTML') === -1,
-      MobileSafari:   /Apple.*Mobile/.test(ua),
-      Android:        ua.indexOf('Linux; Android') > -1
+      MobileSafari:   /Apple.*Mobile/.test(ua)
     }
   })(),
 

--- a/web/page/channel/watch.js
+++ b/web/page/channel/watch.js
@@ -98,12 +98,16 @@ P = Class.create(P, {
 						var d = this.d = this.form.getResult();
 						saveSettings(d);
 
-						var url = location.protocol + '//' + location.host + location.pathname.replace(/\/[^\/]*$/, '');
+						var url = location.host + location.pathname.replace(/\/[^\/]*$/, '');
 
 						url += '/api/channel/';
 						url += this.channelId + '/watch.' + d.ext + '?' + Object.toQueryString(d);
 
-						location.href = "vlc-x-callback://x-callback-url/stream?url=" + encodeURIComponent(url);
+						if (Prototype.Browser.Android) {
+							location.href = "intent://" + url + "#Intent;package=org.videolan.vlc;type=video;scheme=" + location.protocol.replace(':','') + ';end';
+						} else {
+							location.href = "vlc-x-callback://x-callback-url/stream?url=" + encodeURIComponent(location.protocol + '//' + url);
+						}
 					}.bind(this));
 				}.bind(this)
 			});

--- a/web/page/channel/watch.js
+++ b/web/page/channel/watch.js
@@ -103,7 +103,7 @@ P = Class.create(P, {
 						url += '/api/channel/';
 						url += this.channelId + '/watch.' + d.ext + '?' + Object.toQueryString(d);
 
-						if (navigator.userAgent.indexOf('Android') >= 0) {
+						if (/Android/.test(navigator.userAgent) === true) {
 							location.href = "intent://" + url + "#Intent;package=org.videolan.vlc;type=video;scheme=" + location.protocol.replace(':','') + ';end';
 						} else {
 							location.href = "vlc-x-callback://x-callback-url/stream?url=" + encodeURIComponent(location.protocol + '//' + url);

--- a/web/page/channel/watch.js
+++ b/web/page/channel/watch.js
@@ -103,7 +103,7 @@ P = Class.create(P, {
 						url += '/api/channel/';
 						url += this.channelId + '/watch.' + d.ext + '?' + Object.toQueryString(d);
 
-						if (Prototype.Browser.Android) {
+						if (navigator.userAgent.indexOf('Android') >= 0) {
 							location.href = "intent://" + url + "#Intent;package=org.videolan.vlc;type=video;scheme=" + location.protocol.replace(':','') + ';end';
 						} else {
 							location.href = "vlc-x-callback://x-callback-url/stream?url=" + encodeURIComponent(location.protocol + '//' + url);

--- a/web/page/program/watch.js
+++ b/web/page/program/watch.js
@@ -122,7 +122,7 @@ P = Class.create(P, {
 						var d = this.d = this.form.getResult();
 						saveSettings(d);
 
-						var url = location.protocol + '//' + location.host + location.pathname.replace(/\/[^\/]*$/, '');
+						var url = location.host + location.pathname.replace(/\/[^\/]*$/, '');
 
 						if (program._isRecording) {
 							url += '/api/recording/';
@@ -132,7 +132,11 @@ P = Class.create(P, {
 
 						url += program.id + '/watch.' + d.ext + '?' + Object.toQueryString(d);
 
-						location.href = "vlc-x-callback://x-callback-url/stream?url=" + encodeURIComponent(url);
+						if (Prototype.Browser.Android) {
+							location.href = "intent://" + url + "#Intent;package=org.videolan.vlc;type=video;scheme=" + location.protocol.replace(':','') + ';end';
+						} else {
+							location.href = "vlc-x-callback://x-callback-url/stream?url=" + encodeURIComponent(location.protocol + '//' + url);
+						}
 					}.bind(this));
 				}.bind(this)
 			});

--- a/web/page/program/watch.js
+++ b/web/page/program/watch.js
@@ -132,7 +132,7 @@ P = Class.create(P, {
 
 						url += program.id + '/watch.' + d.ext + '?' + Object.toQueryString(d);
 
-						if (Prototype.Browser.Android) {
+						if (navigator.userAgent.indexOf('Android') >= 0) {
 							location.href = "intent://" + url + "#Intent;package=org.videolan.vlc;type=video;scheme=" + location.protocol.replace(':','') + ';end';
 						} else {
 							location.href = "vlc-x-callback://x-callback-url/stream?url=" + encodeURIComponent(location.protocol + '//' + url);

--- a/web/page/program/watch.js
+++ b/web/page/program/watch.js
@@ -132,7 +132,7 @@ P = Class.create(P, {
 
 						url += program.id + '/watch.' + d.ext + '?' + Object.toQueryString(d);
 
-						if (navigator.userAgent.indexOf('Android') >= 0) {
+						if (/Android/.test(navigator.userAgent) === true) {
 							location.href = "intent://" + url + "#Intent;package=org.videolan.vlc;type=video;scheme=" + location.protocol.replace(':','') + ';end';
 						} else {
 							location.href = "vlc-x-callback://x-callback-url/stream?url=" + encodeURIComponent(location.protocol + '//' + url);


### PR DESCRIPTION
AndroidのChromeからアクセスすると、MobileSafari扱いになりvlc-x-callbackスキームで開こうとします。
しかし、Android版のVLCはvlc-x-callbackスキームをサポートしていないため、代わりにintentスキームを使用して開くように変更しました。

これによりAndroidでアクセスした場合、VLCがインストールされていればVLCで。されていなければPlayストアのVLCの画面が表示されるようになります。