### PR TITLE
Content-Typeの値がセットされていない時に500になる点を修正

### DIFF
--- a/api/script-rules.vm.js
+++ b/api/script-rules.vm.js
@@ -8,9 +8,14 @@
 		
 		case 'POST':
 			var newRule = request.query;
-			if (request.headers['content-type'].match(/^application\/json/) === null) {
-				response.error(400);
-			} else if (JSON.stringify(newRule) === '{}') {
+			if (typeof newRule === 'string') {
+				try {
+					newRule = JSON.parse(request.query);
+				} catch (e) {
+					return response.error(400);
+				}
+			}
+			if (JSON.stringify(newRule) === '{}') {
 				response.error(400);
 			} else {
 				if (newRule.isEnabled === false) {


### PR DESCRIPTION
`request.headers['content-type']`が _undefined_ の時にエラーを吹いていたため、
JSONからObjectのパースの確認をcontent-typeのガバガバ文字列一致で検証するのではなく、
パースされていない場合＝すなわち`request.query`の値がStringの場合はパースしてあげることで、
エラー回避と不完全文字列一致の回避をしました。