### PR TITLE
SIDの内部表現が数値になっている事に対応。

### DIFF
--- a/app-cli.js
+++ b/app-cli.js
@@ -277,7 +277,7 @@ if (opts.get('mini') || opts.get('maxi')) {
 	};
 }
 
-if (opts.get('sid'))    rule.sid                  = opts.get('sid');
+if (opts.get('sid'))    rule.sid                  = Number(opts.get('sid'));
 if (opts.get('type'))   rule.types                = opts.get('type').split(',');
 if (opts.get('ch'))     rule.channels             = opts.get('ch').split(',');
 if (opts.get('^ch'))    rule.ignore_channels      = opts.get('^ch').split(',');

--- a/rules.sample.json
+++ b/rules.sample.json
@@ -25,7 +25,7 @@
       "types": ["CS"],
       "channels": ["CS16"],
       "categories": ["anime"],
-      "sid": "333",
+      "sid": 333,
       "duration": {
         "min": 600,
         "max": 10801


### PR DESCRIPTION
chinachu内部でのSIDの表現が数値型になっているので、現状のコードでは「cliの-sidオプションで指定したSIDが文字列とみなされて、検索条件等にマッチしない」等の問題があります。
修正案を考えましたので、ご確認よろしくお願いします。