### PR TITLE
ファイル名に改行を含めないよう修正

### DIFF
--- a/node_modules/chinachu-common/lib/chinachu-common.js
+++ b/node_modules/chinachu-common/lib/chinachu-common.js
@@ -216,6 +216,7 @@ exports.stripFilename = function (a) {
 
 	a = a.replace(/\//g, '／').replace(/\\/g, '＼').replace(/:/g, '：').replace(/\*/g, '＊').replace(/\?/g, '？');
 	a = a.replace(/"/g, '”').replace(/</g, '＜').replace(/>/g, '＞').replace(/\|/g, '｜').replace(/≫/g, '＞＞');
+	a = a.replace(/\r\n/g, ' ').replace(/\n/g, ' ').replace(/\r/g, ' ');
 
 	return a;
 };


### PR DESCRIPTION
録画ファイル名に改行が含まれる場合、EISDIRエラーで録画ファイルに書き込めなくなります。
この問題を修正しました。