### PR TITLE
vp8_vaapiの時は-b:vの指定をしない

### DIFF
--- a/api/script-channel-watch.vm.js
+++ b/api/script-channel-watch.vm.js
@@ -114,7 +114,10 @@ Usushio では使わない
 			if (d.ar) args.push('-ar', d.ar);
 
 			if (d['b:v']) {
-				args.push('-b:v', d['b:v'], '-minrate:v', d['b:v'], '-maxrate:v', d['b:v']);
+				if (d['c:v'] !== 'vp8_vaapi') {
+					args.push('-b:v', d['b:v']);
+				}
+				args.push('-minrate:v', d['b:v'], '-maxrate:v', d['b:v']);
 			}
 			if (d['b:a']) {
 				args.push('-b:a', d['b:a'], '-minrate:a', d['b:a'], '-maxrate:a', d['b:a']);

--- a/api/script-recorded-program-watch.vm.js
+++ b/api/script-recorded-program-watch.vm.js
@@ -233,7 +233,10 @@ function main(avinfo) {
 			if (d.ar) args.push('-ar', d.ar);
 
 			if (d['b:v']) {
-				args.push('-b:v', d['b:v'], '-minrate:v', d['b:v'], '-maxrate:v', d['b:v']);
+				if (d['c:v'] !== 'vp8_vaapi') {
+					args.push('-b:v', d['b:v']);
+				}
+				args.push('-minrate:v', d['b:v'], '-maxrate:v', d['b:v']);
 				args.push('-bufsize:v', videoBitrate * 8);
 			}
 			if (d['b:a']) {

--- a/api/script-recording-program-watch.vm.js
+++ b/api/script-recording-program-watch.vm.js
@@ -125,7 +125,10 @@
 			if (d.ar) args.push('-ar', d.ar);
 
 			if (d['b:v']) {
-				args.push('-b:v', d['b:v'], '-minrate:v', d['b:v'], '-maxrate:v', d['b:v']);
+				if (d['c:v'] !== 'vp8_vaapi') {
+					args.push('-b:v', d['b:v']);
+				}
+				args.push('-minrate:v', d['b:v'], '-maxrate:v', d['b:v']);
 			}
 			if (d['b:a']) {
 				args.push('-b:a', d['b:a'], '-minrate:a', d['b:a'], '-maxrate:a', d['b:a']);


### PR DESCRIPTION
`vaapiEnabled`を`true`にした状態で`webm`で再生しようとすると`ffmpeg`がsegmentation faultを吐いて落ちてしまうようです。

正直`ffmpeg`のバグのような気がしないでもないのですが、`-b:v`の指定を落とすと問題なくなりました。`-b:v`を取り除いても`-minrate`や`-maxrate`の指定があるのでビットレートの制限自体はされるようです。