### PR TITLE
旧チャンネルIDでルールが作れるように

### DIFF
--- a/common/lib/chinachu-common.js
+++ b/common/lib/chinachu-common.js
@@ -278,7 +278,9 @@ exports.programMatchesRule = function (rule, program, nf, fullTitle_norm, detail
 	if (rule.channels) {
 		if (rule.channels.indexOf(program.channel.id) === -1) {
 			if (rule.channels.indexOf(program.channel.channel) === -1) {
-				return false;
+				if (rule.channels.indexOf(program.channel.type+'_'+program.channel.sid) === -1) {
+					return false;
+				}
 			}
 		}
 	}
@@ -289,6 +291,9 @@ exports.programMatchesRule = function (rule, program, nf, fullTitle_norm, detail
 			return false;
 		}
 		if (rule.ignore_channels.indexOf(program.channel.channel) !== -1) {
+			return false;
+		}
+		if (rule.ignore_channels.indexOf(program.channel.type+'_'+program.channel.sid) !== -1) {
 			return false;
 		}
 	}

--- a/web/class.js
+++ b/web/class.js
@@ -132,6 +132,10 @@
 					var candidates = global.chinachu.schedule.pluck('id').concat(global.chinachu.schedule.pluck('channel'));
 
 					var i, l;
+					for (i = 0, l = global.chinachu.schedule.length; i < l; i++) {
+						candidates.push(global.chinachu.schedule[i]['type'] + '_' + global.chinachu.schedule[i]['sid']);
+					}
+
 					for (i = 0, l = candidates.length; i < l; i++) {
 						if (input.match(/^[a-z0-9_]+$/i) === null) {
 							candidates[i] = null;


### PR DESCRIPTION
betaからgammaにアップデートした際に、チャンネルIDの仕様が変更となりました。
しかし、ルールの数が多いと再作成が非常に手間であったため、ルールにおいてはbeta時代のチャンネルIDも使用できるよう、手を加えてみました。

チューナー種別とsidを合わせて作っているだけなので、問題あるようでしたらこのままCloseしてください。

テスト
---

- [x] betaから変更していない旧チャンネルIDのルールと、新IDのルールが混在していても録画されること
- [x] ルール作成画面で新旧両方のIDが候補に出ること
- [x] 新IDでルールが作成できること
- [x] 旧チャンネルIDでルールが作成できること
- [x] ルールの編集が出来ること