### PR TITLE
ディスカバリーチャンネル等のCSチャンネルにおける「flags」取得が上手くできてなかったので修正

### DIFF
--- a/app-scheduler.js
+++ b/app-scheduler.js
@@ -357,8 +357,8 @@ function scheduler() {
 }
 
 // (function) program converter
-const flagBracketsRE = /\[.{1,2}\]|【.】/g;
-const flagExtractRE = /(?:【|\[)(.{1,2})(?:】|\])/;
+const flagBracketsRE = /\[.{1,2}\]|【.】|\(.{1,2}\)/g;
+const flagExtractRE = /(?:【|\[|\()(.{1,2})(?:】|\]|\))/;
 const flagRE = /新|終|再|字|デ|解|無|二|S|SS|初|生|Ｎ|映|多|双/;
 const subtitleRE = /.{3,}([「【]([^」】]+)[」】]).*/;
 const subtitleExRE = /(?:[#＃♯][0-9０-９]{1,3}|[第][0-9０-９]{1,3}[話回])(?:[ 　「]+)([^「」]+)(?:[」]?)/;


### PR DESCRIPTION
ディスカバリーチャンネルやアニマルプラネット等のCSチャンネルでは、多重音声等のタイトル表現が丸括弧区切りによって行われていることがあります。

タイトル例:  `バハマ・ブルー：白砂の楽園(二)`

これに対応するために、正規表現を修正いたしました。