### PR TITLE
naveを3.2.2にアップデート

### DIFF
--- a/chinachu
+++ b/chinachu
@@ -138,9 +138,8 @@ chinachu_installer_node () {
   ensure_dir "$NAVE_DIR"
 
   echo "Installing Node using Nave..."
-  wget -O - https://github.com/isaacs/nave/archive/v2.3.0.tar.gz | tar zxvf - -C $NAVE_DIR nave-2.3.0/nave.sh
-  mv $NAVE_DIR/nave-2.3.0/nave.sh $NAVE_DIR/
-  rm -rfv $NAVE_DIR/nave-2.3.0
+  wget -O $NAVE_DIR/nave.sh https://raw.githubusercontent.com/isaacs/nave/v3.2.2/nave.sh
+  chmod a+x $NAVE_DIR/nave.sh
   ${NAVE_DIR}/nave.sh install $NODE_VER
   rm -fv ${NAVE_DIR}/node
   ln -sv $NODE_PATH ${NAVE_DIR}/node


### PR DESCRIPTION
2.3.0だとRaspberry Pi OSでは

https://nodejs.org/dist/v10.16.3/node-v10.16.3-linux-.tar.gz

にアクセスしようとして次のエラーで失敗

```
curl: (22) The requested URL returned error: 404
shasum mismatch, expect , got

gzip: stdin: unexpected end of file
tar: Child returned status 1
tar: Error is not recoverable: exiting now
Binary install failed, trying source.
```

3.2.2は正しくこちらから取得

https://nodejs.org/dist/v10.16.3/node-v10.16.3.tar.gz